### PR TITLE
Fix contains condition support for string arrays (#416)

### DIFF
--- a/src/DotLiquid.Tests/ConditionTests.cs
+++ b/src/DotLiquid.Tests/ConditionTests.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Text.RegularExpressions;
 using DotLiquid.Exceptions;
 using DotLiquid.NamingConventions;
@@ -9,6 +11,40 @@ namespace DotLiquid.Tests
     [TestFixture]
     public class ConditionTests
     {
+        #region Classes used in tests
+        public class Car : Drop, System.IEquatable<Car>, System.IEquatable<string>
+        {
+            public string Make { get; set; }
+            public string Model { get; set; }
+
+            public override string ToString()
+            {
+                return $"{Make} {Model}";
+            }
+
+            public override bool Equals(object other)
+            {
+                if (other is Car @car)
+                    return Equals(@car);
+
+                if (other is string @string)
+                    return Equals(@string);
+
+                return false;
+            }
+
+            public bool Equals(Car other)
+            {
+                return other.Make == this.Make && other.Model == this.Model;
+            }
+
+            public bool Equals(string other)
+            {
+                return other == this.ToString();
+            }
+        }
+        #endregion
+
         // NOTE(David Burg): This forces sequential execution of tests, risk side effect resulting in non deterministic behavior.
         // Context should be passed as a parameter instead.
         private Context _context;
@@ -119,10 +155,124 @@ namespace DotLiquid.Tests
 
             AssertEvaluatesTrue("array", "contains", "1");
             AssertEvaluatesFalse("array", "contains", "0");
+            AssertEvaluatesTrue("array", "contains", "1.0");
             AssertEvaluatesTrue("array", "contains", "2");
             AssertEvaluatesTrue("array", "contains", "3");
             AssertEvaluatesTrue("array", "contains", "4");
             AssertEvaluatesTrue("array", "contains", "5");
+            AssertEvaluatesFalse("array", "contains", "6");
+
+            AssertEvaluatesFalse("array", "contains", "'1'");
+        }
+
+        [Test]
+        public void TestStringArrays()
+        {
+            _context = new Context(CultureInfo.InvariantCulture);
+            var _array = new List<string>() { "Apple", "Orange", null, "Banana" };
+            _context["array"] = _array.ToArray();
+            _context["first"] = _array.First();
+            _context["last"] = _array.Last();
+
+            AssertEvaluatesTrue(left: "array", op: "contains", right: "'Apple'");
+            AssertEvaluatesTrue(left: "array", op: "startsWith", right: "first");
+            AssertEvaluatesTrue(left: "array.first", op: "==", right: "first");
+            AssertEvaluatesFalse(left: "array", op: "contains", right: "'apple'");
+            AssertEvaluatesFalse(left: "array", op: "startsWith", right: "'apple'");
+            AssertEvaluatesFalse(left: "array.first", op: "==", right: "'apple'");
+            AssertEvaluatesFalse(left: "array", op: "contains", right: "'Mango'");
+            AssertEvaluatesTrue(left: "array", op: "contains", right: "'Orange'");
+            AssertEvaluatesTrue(left: "array", op: "contains", right: "'Banana'");
+            AssertEvaluatesTrue(left: "array", op: "endsWith", right: "last");
+            AssertEvaluatesFalse(left: "array", op: "contains", right: "'Orang'");
+        }
+
+        [Test]
+        public void TestClassArrays()
+        {
+            _context = new Context(CultureInfo.InvariantCulture);
+            var _array = new List<Car>() { new Car() { Make = "Honda", Model = "Accord" }, new Car() { Make = "Ford", Model = "Explorer" } };
+            _context["array"] = _array.ToArray();
+            _context["first"] = _array.First();
+            _context["last"] = _array.Last();
+            _context["clone"] = new Car() { Make = "Honda", Model = "Accord" };
+            _context["camry"] = new Car() { Make = "Toyota", Model = "Camry" };
+
+            AssertEvaluatesTrue(left: "array", op: "contains", right: "first");
+            AssertEvaluatesTrue(left: "array", op: "startsWith", right: "first");
+            AssertEvaluatesTrue(left: "array.first", op: "==", right: "first");
+            AssertEvaluatesTrue(left: "array", op: "contains", right: "clone");
+            AssertEvaluatesTrue(left: "array", op: "startsWith", right: "clone");
+            AssertEvaluatesTrue(left: "array", op: "endsWith", right: "last");
+            AssertEvaluatesFalse(left: "array", op: "contains", right: "camry");
+        }
+
+        [Test]
+        public void TestTruthyArray()
+        {
+            _context = new Context(CultureInfo.InvariantCulture);
+            var _array = new List<bool>() { true };
+            _context["array"] = _array.ToArray();
+            _context["first"] = _array.First();
+
+            AssertEvaluatesTrue(left: "array", op: "contains", right: "first");
+            AssertEvaluatesTrue(left: "array", op: "startsWith", right: "first");
+            AssertEvaluatesTrue(left: "array.first", op: "==", right: "'true'");
+            AssertEvaluatesTrue(left: "array", op: "startsWith", right: "'true'");
+
+            AssertEvaluatesFalse(left: "array", op: "contains", right: "'true'"); // to be re-evaluated in #362
+        }
+
+        [Test]
+        public void TestCharArrays()
+        {
+            _context = new Context(CultureInfo.InvariantCulture);
+            var _array = new List<char> { 'A', 'B', 'C' };
+            _context["array"] = _array.ToArray();
+            _context["first"] = _array.First();
+            _context["last"] = _array.Last();
+
+            AssertEvaluatesTrue(left: "array", op: "contains", right: "'A'");
+            AssertEvaluatesTrue(left: "array", op: "contains", right: "first");
+            AssertEvaluatesTrue(left: "array", op: "startsWith", right: "first");
+            AssertEvaluatesTrue(left: "array.first", op: "==", right: "first");
+            AssertEvaluatesFalse(left: "array", op: "contains", right: "'a'");
+            AssertEvaluatesFalse(left: "array", op: "contains", right: "'X'");
+            AssertEvaluatesTrue(left: "array", op: "contains", right: "'B'");
+            AssertEvaluatesTrue(left: "array", op: "contains", right: "'C'");
+            AssertEvaluatesTrue(left: "array", op: "endsWith", right: "last");
+        }
+
+        [Test]
+        public void TestByteArrays()
+        {
+            _context = new Context(CultureInfo.InvariantCulture);
+            var _array = new List<byte> { 0x01, 0x02, 0x03, 0x30 };
+            _context["array"] = _array.ToArray();
+            _context["first"] = _array.First();
+            _context["last"] = _array.Last();
+
+            AssertEvaluatesFalse(left: "array", op: "contains", right: "0");
+            AssertEvaluatesFalse(left: "array", op: "contains", right: "'0'");
+            AssertEvaluatesTrue(left: "array", op: "startsWith", right: "first");
+            AssertEvaluatesTrue(left: "array.first", op: "==", right: "first");
+            AssertEvaluatesTrue(left: "array", op: "contains", right: "first");
+            AssertEvaluatesFalse(left: "array", op: "contains", right: "1");
+            AssertEvaluatesTrue(left: "array", op: "endsWith", right: "last");
+        }
+
+        [Test]
+        public void TestContainsWorksOnDoubleArrays()
+        {
+            _context = new Context(CultureInfo.InvariantCulture);
+            _context["array"] = new double[] { 1.0, 2.1, 3.25, 4.333, 5.0 };
+
+            AssertEvaluatesTrue("array", "contains", "1.0");
+            AssertEvaluatesFalse("array", "contains", "0");
+            AssertEvaluatesTrue("array", "contains", "2.1");
+            AssertEvaluatesFalse("array", "contains", "3");
+            AssertEvaluatesFalse("array", "contains", "4.33");
+            AssertEvaluatesTrue("array", "contains", "5.00");
             AssertEvaluatesFalse("array", "contains", "6");
 
             AssertEvaluatesFalse("array", "contains", "'1'");


### PR DESCRIPTION
* Fix contains condition support boundary for non-numeric types

* Additional Tests comparing first filter to startsWith conditional operator

Co-authored-by: Moshe Alfih <malfih@itgny.com>