### PR TITLE
Check for specific exception types

### DIFF
--- a/src/DotLiquid.Tests/Embedded/golden_rules.json
+++ b/src/DotLiquid.Tests/Embedded/golden_rules.json
@@ -37,7 +37,6 @@
         "liquid.golden.default_filter - render a default given a literal false with 'allow false' equal to false",
         "liquid.golden.default_filter - render a default given a literal false with 'allow false' equal to true",
         // DotLiquid #457
-        "liquid.golden.date_filter - seconds since epoch format directive",
         "liquid.golden.date_filter - timestamp string",
         // DotLiquid #549
         "liquid.golden.first_filter - first of a string",


### PR DESCRIPTION
This is really just a way of me expressing an idea, so feel free to close this and maybe take inspiration?

I'm concerned that the golden tests aren't checking for specific exceptions. In particular:
- I would expect the tests where `error = true` should be throwing a subclass of LiquidException
- I would expect the "failing tests" to be throwing an AssertException (i.e. the test has failed, rather than the code throwing an exception).

This PR tries to expose that behaviour, but that means that the tests that were previously passing are now failing due to the wrong exception type. 

I also split the failing test into one per test, like the passing test.